### PR TITLE
Add UDP telemetry listener and Vue speed display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# F1Manager
+# F1 Manager Telemetry Viewer
+
+An Electron + Vue 3 desktop application that listens to F1 25 UDP telemetry packets and visualises the live car speed with a modern TailwindCSS UI.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+This starts the Vite development server and launches the Electron window. Make sure F1 25 is configured to broadcast telemetry to `0.0.0.0:20777`.
+
+## Building
+
+```bash
+npm run build
+```
+
+The build command bundles the Vue frontend and compiles the Electron main process into `dist-electron/`.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,96 @@
+import { app, BrowserWindow, shell } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { startUdpListener } from './udp-listener';
+
+if (!process.env.NODE_ENV) {
+  process.env.NODE_ENV = app.isPackaged ? 'production' : 'development';
+}
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+let stopListener: (() => void) | null = null;
+
+const resolvePreloadPath = () => {
+  const candidates = [
+    path.join(__dirname, 'preload.js'),
+    path.join(__dirname, '../electron/preload.js'),
+    path.join(__dirname, 'preload.ts'),
+    path.join(__dirname, '../electron/preload.ts')
+  ];
+
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  return found ?? path.join(__dirname, 'preload.js');
+};
+
+const createWindow = () => {
+  const preloadPath = resolvePreloadPath();
+
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 720,
+    show: false,
+    backgroundColor: '#0b1120',
+    webPreferences: {
+      preload: preloadPath,
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  });
+
+  win.once('ready-to-show', () => {
+    win.show();
+  });
+
+  if (isDev) {
+    win.webContents.openDevTools({ mode: 'detach' }).catch(() => undefined);
+  }
+
+  const devServerUrl = process.env.VITE_DEV_SERVER_URL;
+  const indexHtmlPath = path.join(__dirname, '../dist/index.html');
+
+  if (isDev && devServerUrl) {
+    win.loadURL(devServerUrl).catch((error) => {
+      console.error('Failed to load renderer', error);
+    });
+  } else if (fs.existsSync(indexHtmlPath)) {
+    win.loadFile(indexHtmlPath).catch((error) => {
+      console.error('Failed to load renderer file', error);
+    });
+  } else {
+    const fallbackUrl = 'http://localhost:5173';
+    win.loadURL(fallbackUrl).catch((error) => {
+      console.error('Failed to load fallback renderer URL', error);
+    });
+  }
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url).catch(() => undefined);
+    return { action: 'deny' };
+  });
+
+  stopListener = startUdpListener(win);
+
+  return win;
+};
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (stopListener) {
+    stopListener();
+    stopListener = null;
+  }
+
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,25 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+type SpeedCallback = (speed: number) => void;
+
+declare global {
+  interface Window {
+    electronAPI: {
+      onSpeedUpdate: (callback: SpeedCallback) => () => void;
+    };
+  }
+}
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  onSpeedUpdate: (callback: SpeedCallback) => {
+    const listener = (_event: Electron.IpcRendererEvent, speed: number) => {
+      callback(speed);
+    };
+
+    ipcRenderer.on('telemetry:speed', listener);
+
+    return () => {
+      ipcRenderer.removeListener('telemetry:speed', listener);
+    };
+  }
+});

--- a/electron/udp-listener.ts
+++ b/electron/udp-listener.ts
@@ -1,0 +1,77 @@
+import dgram from 'node:dgram';
+import type { BrowserWindow } from 'electron';
+import * as F1ParserModule from '@deltazeroproduction/f1-udp-parser';
+
+type SpeedListenerCleanup = () => void;
+
+interface CarTelemetryPacket {
+  m_header?: {
+    m_packetId?: number;
+  };
+  m_carTelemetryData?: Array<{
+    m_speed?: number;
+  }>;
+}
+
+const CAR_TELEMETRY_PACKET_ID = 6;
+const UDP_PORT = 20777;
+const UDP_HOST = '0.0.0.0';
+
+const ParserConstructor: new () => any =
+  (F1ParserModule as { F1Parser?: new () => any }).F1Parser ??
+  (F1ParserModule as { default?: new () => any }).default ??
+  (F1ParserModule as unknown as new () => any);
+
+export const startUdpListener = (win: BrowserWindow): SpeedListenerCleanup => {
+  const socket = dgram.createSocket('udp4');
+  const parser: any = new ParserConstructor();
+
+  const forwardSpeed = (speed: number) => {
+    if (!win.isDestroyed()) {
+      win.webContents.send('telemetry:speed', speed);
+    }
+  };
+
+  socket.on('message', (message) => {
+    try {
+      const packet: CarTelemetryPacket | undefined =
+        typeof parser.fromBuffer === 'function'
+          ? parser.fromBuffer(message)
+          : typeof parser.parseBuffer === 'function'
+          ? parser.parseBuffer(message)
+          : typeof parser.parse === 'function'
+          ? parser.parse(message)
+          : undefined;
+
+      if (packet?.m_header?.m_packetId === CAR_TELEMETRY_PACKET_ID) {
+        const speed = packet.m_carTelemetryData?.[0]?.m_speed;
+        if (typeof speed === 'number' && !Number.isNaN(speed)) {
+          forwardSpeed(speed);
+        }
+      }
+    } catch (error) {
+      console.error('[UDP Listener] Failed to parse telemetry packet', error);
+    }
+  });
+
+  socket.on('error', (error) => {
+    console.error('[UDP Listener] Socket error', error);
+  });
+
+  socket.bind(UDP_PORT, UDP_HOST, () => {
+    console.log(`[UDP Listener] Listening on ${UDP_HOST}:${UDP_PORT}`);
+  });
+
+  const cleanup = () => {
+    socket.removeAllListeners();
+    try {
+      socket.close();
+    } catch (error) {
+      console.error('[UDP Listener] Failed to close socket', error);
+    }
+  };
+
+  win.once('closed', cleanup);
+
+  return cleanup;
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>F1 Manager Telemetry</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "f1-manager",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Electron application for viewing F1 25 telemetry data in real time.",
+  "main": "dist-electron/main.js",
+  "scripts": {
+    "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:electron\"",
+    "dev:renderer": "cross-env NODE_ENV=development vite",
+    "dev:electron": "cross-env NODE_ENV=development VITE_DEV_SERVER_URL=http://localhost:5173 wait-on tcp:5173 && electron -r ts-node/register/transpile-only electron/main.ts",
+    "build": "cross-env NODE_ENV=production vite build && cross-env NODE_ENV=production npm run build:electron",
+    "build:electron": "tsc -p tsconfig.node.json",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@deltazeroproduction/f1-udp-parser": "^2.0.1",
+    "electron": "^28.3.3",
+    "vue": "^3.4.21"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "autoprefixer": "^10.4.17",
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.1.6",
+    "wait-on": "^7.2.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+    <SpeedDisplay />
+  </div>
+</template>
+
+<script setup lang="ts">
+import SpeedDisplay from './components/SpeedDisplay.vue';
+</script>

--- a/src/components/SpeedDisplay.vue
+++ b/src/components/SpeedDisplay.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="relative">
+    <div
+      class="max-w-md mx-auto rounded-3xl bg-white/10 backdrop-blur-xl shadow-2xl shadow-indigo-900/30 border border-white/10 px-10 py-12 text-center"
+    >
+      <p class="uppercase tracking-[0.35em] text-xs text-indigo-300 mb-6">Live Speed</p>
+      <transition name="speed-change" mode="out-in">
+        <p
+          :key="displaySpeed"
+          class="text-7xl md:text-8xl font-semibold text-white drop-shadow-[0_20px_30px_rgba(79,70,229,0.45)]"
+        >
+          <span>{{ displaySpeed }}</span>
+          <span class="ml-2 text-2xl text-indigo-200">km/h</span>
+        </p>
+      </transition>
+      <div class="mt-8 flex items-center justify-center space-x-2 text-sm text-indigo-200/80">
+        <span class="inline-block h-2 w-2 rounded-full bg-emerald-400 animate-pulse"></span>
+        <span>Telemetry streaming from F1 25</span>
+      </div>
+    </div>
+    <div class="absolute -inset-6 -z-10 bg-gradient-to-r from-indigo-500/40 via-purple-500/40 to-sky-500/40 blur-3xl opacity-60"></div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+
+const speed = ref<number | null>(null);
+
+const formatSpeed = (value: number | null) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.round(value).toString().padStart(3, '0');
+  }
+  return '---';
+};
+
+const displaySpeed = ref(formatSpeed(speed.value));
+
+let unsubscribe: (() => void) | undefined;
+
+onMounted(() => {
+  if (window.electronAPI?.onSpeedUpdate) {
+    unsubscribe = window.electronAPI.onSpeedUpdate((incomingSpeed) => {
+      speed.value = incomingSpeed;
+      displaySpeed.value = formatSpeed(incomingSpeed);
+    });
+  }
+});
+
+onBeforeUnmount(() => {
+  unsubscribe?.();
+});
+</script>
+
+<style scoped>
+.speed-change-enter-active,
+.speed-change-leave-active {
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.speed-change-enter-from,
+.speed-change-leave-to {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
+}
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare interface Window {
+  electronAPI?: {
+    onSpeedUpdate: (callback: (speed: number) => void) => () => void;
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-slate-950 text-white font-sans min-h-screen;
+}
+
+#app {
+  min-height: 100vh;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+import './index.css';
+
+createApp(App).mount('#app');

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['\"Inter\"', 'system-ui', 'sans-serif']
+      }
+    }
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "references": [
+    { "path": "tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist-electron",
+    "rootDir": "electron",
+    "types": ["node"]
+  },
+  "include": ["electron/**/*.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src')
+    }
+  },
+  server: {
+    port: 5173,
+    strictPort: true
+  }
+});


### PR DESCRIPTION
## Summary
- add an Electron UDP listener that parses F1 25 telemetry speed data and forwards it over IPC
- expose a preload bridge plus Vue 3 components styled with TailwindCSS to render live speed updates
- scaffold the project configuration for Electron, Vite, Tailwind, and TypeScript development

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93fb2af548323bdf9fcb5a265002e